### PR TITLE
Added dnsserver.listenerTLS object

### DIFF
--- a/core/dnsserver/server-tls.go
+++ b/core/dnsserver/server-tls.go
@@ -59,7 +59,10 @@ func (s *ServerTLS) Listen() (net.Listener, error) {
 	if tlsConfig == nil {
 		l, err = net.Listen("tcp", s.Addr[len(TransportTLS+"://"):])
 	} else {
-		l, err = tls.Listen("tcp", s.Addr[len(TransportTLS+"://"):], tlsConfig)
+		var innerListener net.Listener
+		innerListener, err = net.Listen("tcp", s.Addr[len(TransportGRPC+"://"):])
+		tlsListener := tls.NewListener(innerListener, tlsConfig)
+		l = listenerTLS{Listener: tlsListener, innerListener: innerListener}
 	}
 
 	if err != nil {


### PR DESCRIPTION
The original ServergRPC.Listen() methods returns a tls.Listener
when tls protocol is specified. Unfortunate, tls.Listener
does not implement the caddy.Listener interface that is
needed for graceful restart to work.

dnsserver.listenerTLS object is implemented to statisfy the
caddy.TLSlistener contract in order to support graceful restart.

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
 Allow graceful restart for TLS Listener

### 2. Which issues (if any) are related?
 https://github.com/coredns/coredns/issues/1244

### 3. Which documentation changes (if any) need to be made?

